### PR TITLE
Add long-read support to roadmap_5 with new BAM output controls

### DIFF
--- a/configs/modules.config
+++ b/configs/modules.config
@@ -94,6 +94,20 @@ process{
         container="docker://parsaghadermazi/roadmap1:amd64"
     }
 
+    withName: "map_long_reads_fasta_pairs"{
+        memory = '30 GB'
+        time = '10h'
+        cpus = 8
+        container="docker://parsaghadermazi/roadmap9:amd64"
+    }
+
+    withName: "finalize_alignment_bam"{
+        memory = '8 GB'
+        time = '1h'
+        cpus = 2
+        container="docker://parsaghadermazi/roadmap1:amd64"
+    }
+
     withName: "convert_sam_to_bam"{
         memory = '12 GB'
         time = '1h'

--- a/docs/roadmaps.md
+++ b/docs/roadmaps.md
@@ -421,34 +421,110 @@ Usually this option is used to prioritize specific genomes.
 
 #### Description
 
-This roadmap is designed only to map a set of reads to a set of reference genomes. It offers two modes of operation:
+This roadmap maps a set of reads to a set of reference genomes and outputs a BAM file per sample/genome pair. It supports both **short reads** (Illumina, via Bowtie2) and **long reads** (Oxford Nanopore or PacBio, via minimap2).
 
-1. **paired** : The reads are pared with genomes so any task would be aligning the reads to the corresponding genome.
-2. **cross** : Each sample is aligned to each fasta file in the input genomes.
+Two pairing modes are available:
+
+1. **paired** (default): Each sample is aligned to its corresponding genome (1-to-1 pairing; the CSV row order must match).
+2. **cross**: Each sample is aligned to every genome in the reference set.
+
+**BAM output behaviour:**
+
+By default, the output BAM contains **mapped reads only**. This is the most common use case and avoids large output files. Use the flags below to change this:
+
+| Flag | Effect |
+|------|--------|
+| *(none — default)* | Mapped-only BAM |
+| `--keep_unmapped_reads` | Full BAM (mapped + unmapped reads retained) |
+| `--get_mapped_reads` | Also produce a FASTQ of mapped reads |
+| `--get_unmapped_reads` | Also produce a FASTQ of unmapped reads |
+
+`--get_mapped_reads` and `--get_unmapped_reads` can be combined and are independent of `--keep_unmapped_reads`.
 
 ![roadmap_5](../imgs/dag-roadmap_5.svg)
 
-#### How to run
+#### How to run — short reads (default)
 
-To run this roadmap, you need to provide a CSV file containing the following columns:
+Provide a CSV with the following columns:
 
-- sample_name
-- reads1
-- reads2
+- `sample_name`
+- `reads1`
+- `reads2`
 
-Also, you need to provide a CSV file containing the paths to the genomes you want to map the reads to. This file should contain one column:
+And a genome CSV with one column:
 
-- fasta_files (address to each fasta file)
-
-You can run the roadmap using the following command:
+- `fasta_files`
 
 ```bash
-nextflow run pipelines.nf --roadmap_id "roadmap_5" --input_reads "<path-to-samples.csv>" --input_fastas "<path-to-genomes.csv>" -profile apptainer,alpine
+nextflow run pipelines.nf --roadmap_id "roadmap_5" \
+    --input_reads "<path-to-samples.csv>" \
+    --input_fastas "<path-to-genomes.csv>" \
+    -profile apptainer,alpine
+```
+
+#### How to run — long reads (Nanopore / PacBio)
+
+> **Important**: Long-read mode uses a **different CSV format** from short reads. This is intentional — long reads are single-end and require careful validation before running.
+
+Provide a CSV with the following columns:
+
+- `sample_name`
+- `reads` *(single FASTQ file per sample — do **not** use `reads1`/`reads2`)*
+
+And a genome CSV with one column:
+
+- `fasta_files`
+
+Pass `--read_type` to select the sequencing technology. This controls the minimap2 preset:
+
+| `--read_type` | Technology | minimap2 preset |
+|---|---|---|
+| `nanopore` | Oxford Nanopore (ONT) | `map-ont` |
+| `pacbio_clr` | PacBio CLR (continuous long reads) | `map-pb` |
+| `pacbio_hifi` | PacBio HiFi / CCS (high-accuracy) | `map-hifi` |
+
+**Nanopore example:**
+
+```bash
+nextflow run pipelines.nf --roadmap_id "roadmap_5" \
+    --read_type nanopore \
+    --input_type local \
+    --input_reads "<path-to-long-reads.csv>" \
+    --input_fastas "<path-to-genomes.csv>" \
+    -profile apptainer,alpine
+```
+
+**PacBio HiFi example:**
+
+```bash
+nextflow run pipelines.nf --roadmap_id "roadmap_5" \
+    --read_type pacbio_hifi \
+    --input_type local \
+    --input_reads "<path-to-long-reads.csv>" \
+    --input_fastas "<path-to-genomes.csv>" \
+    -profile apptainer,alpine
+```
+
+> **Note**: SRA (`--input_type sra`) is not currently supported for long reads. Provide local FASTQ files.
+
+#### Example: keep full BAM and extract unmapped reads as FASTQ
+
+```bash
+nextflow run pipelines.nf --roadmap_id "roadmap_5" \
+    --input_reads "<path-to-samples.csv>" \
+    --input_fastas "<path-to-genomes.csv>" \
+    --keep_unmapped_reads \
+    --get_unmapped_reads \
+    -profile apptainer,alpine
 ```
 
 ##### Relevant optional arguments
 
-- **--roadmap_5_pairmode** : By default, the roadmap runs in pair mode. Otherwise, you should provide "cross" as the argument.
+- **--read_type** : Sequencing technology. One of `short` (default), `nanopore`, `pacbio_clr`, `pacbio_hifi`.
+- **--roadmap_5_pairmode** : Pairing mode. `paired` (default) or `cross`.
+- **--keep_unmapped_reads** : Retain unmapped reads in the output BAM (default: mapped-only BAM).
+- **--get_mapped_reads** : Additionally write a FASTQ file of mapped reads.
+- **--get_unmapped_reads** : Additionally write a FASTQ file of unmapped reads.
 
 ------
 

--- a/modules/alignment/main.nf
+++ b/modules/alignment/main.nf
@@ -240,7 +240,8 @@ process map_reads_fasta_pairs{
     /*
     * This process lumps indexing and mapping of reads to a genome. It  is useful for when we have read-genome pairs.
     */
-    publishDir "${params.output_dir}/bowtie2_alignment/${sample_name}_${reference_fasta.baseName}", mode: 'copy', pattern: "*sorted.bam"
+    // Publishing is suppressed when called from roadmap_5; finalize_alignment_bam handles it there.
+    publishDir "${params.output_dir}/bowtie2_alignment/${sample_name}_${reference_fasta.baseName}", mode: 'copy', pattern: "*sorted.bam", enabled: params.get('roadmap_id', '') != "roadmap_5"
     input:
     val sample_name
     path reads
@@ -276,6 +277,64 @@ process map_reads_fasta_pairs{
         """
     }
 
+}
+
+process map_long_reads_fasta_pairs {
+    /*
+     * Aligns long reads to a reference genome using minimap2.
+     * The preset is chosen from params.read_type:
+     *   nanopore   -> map-ont
+     *   pacbio_clr -> map-pb
+     *   pacbio_hifi -> map-hifi
+     * Output is a full sorted BAM (mapped + unmapped). Use finalize_alignment_bam
+     * to produce the published BAM with optional unmapped-read filtering.
+     */
+    input:
+    val sample_name
+    path reads
+    path reference_fasta
+    output:
+    path "${sample_name}_${reference_fasta.baseName}.sorted.bam", emit: sorted_bam
+    val sample_name, emit: sample_name
+    val false, emit: paired
+
+    script:
+    def preset = (params.read_type == "nanopore")    ? "map-ont"  :
+                 (params.read_type == "pacbio_clr")  ? "map-pb"   :
+                                                        "map-hifi"
+    """
+    minimap2 -ax ${preset} -t ${task.cpus} ${reference_fasta} ${reads} | \\
+        samtools view -bS - | \\
+        samtools sort -o ${sample_name}_${reference_fasta.baseName}.sorted.bam
+    """
+}
+
+process finalize_alignment_bam {
+    /*
+     * Publishes the final BAM for roadmap_5.
+     * By default, unmapped reads are filtered out (mapped-only BAM).
+     * With --keep_unmapped_reads the full BAM is published instead.
+     * FASTQ extraction (--get_mapped_reads / --get_unmapped_reads) runs
+     * separately on the pre-filter BAM so no reads are lost.
+     */
+    publishDir "${params.output_dir}/alignment/${sample_name}", mode: 'copy'
+    input:
+    path sorted_bam
+    val sample_name
+    output:
+    path "${sorted_bam.baseName}.final.bam", emit: final_bam
+    val sample_name, emit: sample_name
+
+    script:
+    if (params.keep_unmapped_reads) {
+        """
+        cp ${sorted_bam} ${sorted_bam.baseName}.final.bam
+        """
+    } else {
+        """
+        samtools view -b -F 4 ${sorted_bam} -o ${sorted_bam.baseName}.final.bam
+        """
+    }
 }
 
 process index_star {

--- a/pipelines.nf
+++ b/pipelines.nf
@@ -13,6 +13,10 @@ params.is_genome_db=null // default is null
 params.is_stb_db=null // default is null
 params.is_genes=null // default is null
 params.roadmap_5_pairmode="paired"
+params.read_type="short"              // Sequencing technology: short, nanopore, pacbio_clr, pacbio_hifi
+params.keep_unmapped_reads=false      // Include unmapped reads in output BAM (default: mapped-only BAM)
+params.get_mapped_reads=false         // Additionally output a FASTQ of mapped reads
+params.get_unmapped_reads=false       // Additionally output a FASTQ of unmapped reads
 params.metaphlan_b_distance="bray-curtis"
 params.metaphlan_diversity="beta"
 params.sylph_db = null
@@ -224,40 +228,79 @@ workflow {
         {
             error "Please provide the reads information using the input_reads parameter."
         }
-        if (params.input_type=="sra")
+        def valid_read_types = ["short", "nanopore", "pacbio_clr", "pacbio_hifi"]
+        if (!valid_read_types.contains(params.read_type))
         {
-            table=tableToDict(file("${params.input_reads}"))
-            get_sequences_from_sra(Channel.fromList(table["Run"]))
-            sample_names=get_sequences_from_sra.out.sra_ids
-            reads=get_sequences_from_sra.out.fastq_files.map{t->[t]}
+            error "Invalid --read_type '${params.read_type}'. Must be one of: ${valid_read_types.join(', ')}"
         }
-        else if (params.input_type=="local")
+        if (params.read_type == "short")
         {
-            table=tableToDict(file("${params.input_reads}"))
-            reads_1=Channel.fromPath(table["reads1"].collect{t->file(t)})
-            reads_2=Channel.fromPath(table["reads2"].collect{t->file(t)})
-            reads=reads_1.merge(reads_2)
-            sample_names=Channel.fromList(table["sample_name"])
-            
+            // Short reads: CSV must have columns: sample_name, reads1, reads2
+            if (params.input_type=="sra")
+            {
+                table=tableToDict(file("${params.input_reads}"))
+                get_sequences_from_sra(Channel.fromList(table["Run"]))
+                sample_names=get_sequences_from_sra.out.sra_ids
+                reads=get_sequences_from_sra.out.fastq_files.map{t->[t]}
+            }
+            else if (params.input_type=="local")
+            {
+                table=tableToDict(file("${params.input_reads}"))
+                reads_1=Channel.fromPath(table["reads1"].collect{t->file(t)})
+                reads_2=Channel.fromPath(table["reads2"].collect{t->file(t)})
+                reads=reads_1.merge(reads_2)
+                sample_names=Channel.fromList(table["sample_name"])
+            }
+            samples_reads=sample_names.merge(reads)
+            genomes=Channel.fromPath(tableToDict(file("${params.input_fastas}"))["fasta_files"].collect{t->file(t)})
+            if (params.roadmap_5_pairmode=="cross")
+            {
+                samples_reads.combine(genomes).set{inputs}
+            }
+            else if (params.roadmap_5_pairmode=="paired")
+            {
+                samples_reads.merge(genomes).set{inputs}
+            }
+            inputs.multiMap{v->
+                sn:v[0]
+                rd:v[1]
+                gn:v[2]
+                tr:(v[1].size() == 2)
+            }.set{ins}
+            roadmap_5(ins.sn, ins.rd, ins.gn, ins.tr)
         }
-        samples_reads=sample_names.merge(reads)
-        genomes=Channel.fromPath(tableToDict(file("${params.input_fastas}"))["fasta_files"].collect{t->file(t)})
-        if (params.roadmap_5_pairmode=="cross")
+        else
         {
-            samples_reads.combine(genomes).set{inputs}
+            // Long reads (nanopore, pacbio_clr, pacbio_hifi): CSV must have columns: sample_name, reads
+            // NOTE: SRA downloads are not supported for long reads. Provide local FASTQ files.
+            if (params.input_type=="sra")
+            {
+                error "SRA input is not supported for long reads in roadmap_5. Please provide local long-read FASTQ files using --input_type local."
+            }
+            else if (params.input_type=="local")
+            {
+                table=tableToDict(file("${params.input_reads}"))
+                reads=Channel.fromPath(table["reads"].collect{t->file(t)})
+                sample_names=Channel.fromList(table["sample_name"])
+            }
+            samples_reads=sample_names.merge(reads)
+            genomes=Channel.fromPath(tableToDict(file("${params.input_fastas}"))["fasta_files"].collect{t->file(t)})
+            if (params.roadmap_5_pairmode=="cross")
+            {
+                samples_reads.combine(genomes).set{inputs}
+            }
+            else if (params.roadmap_5_pairmode=="paired")
+            {
+                samples_reads.merge(genomes).set{inputs}
+            }
+            inputs.multiMap{v->
+                sn: v[0]
+                rd: v[1]
+                gn: v[2]
+                tr: false   // long reads are always single-end
+            }.set{ins}
+            roadmap_5(ins.sn, ins.rd, ins.gn, ins.tr)
         }
-        else if (params.roadmap_5_pairmode=="paired")
-        {
-            samples_reads.merge(genomes).set{inputs}
-        }
-        inputs.multiMap{v->
-            sn:v[0]
-            rd:v[1]
-            gn:v[2]
-            tr:(v[1].size() == 2)
-        }.set{ins}
-        roadmap_5(ins.sn, ins.rd, ins.gn,ins.tr)
-
     }
     else if (params.roadmap_id=="roadmap_6")
     {
@@ -601,18 +644,63 @@ workflow roadmap_3_2 {
 }
 
 workflow roadmap_5 {
-    //This roadmap is a minimal roadmap for mapping reads a set of reads to a set of genomes 
+    /*
+     * Maps reads to reference genomes. Supports short reads (bowtie2) and long reads
+     * (minimap2: nanopore, pacbio_clr, pacbio_hifi). Controlled by --read_type.
+     *
+     * Default output: mapped-only BAM per sample/genome pair.
+     * --keep_unmapped_reads : output BAM retains unmapped reads as well.
+     * --get_mapped_reads    : additionally produce a FASTQ of mapped reads.
+     * --get_unmapped_reads  : additionally produce a FASTQ of unmapped reads.
+     */
     take:
     sample_name
     reads
     genome
     paired
-    
-    main:
-    map_reads_fasta_pairs(sample_name, reads, genome,paired)
-    get_mapped_reads(map_reads_fasta_pairs.out.sorted_bam,map_reads_fasta_pairs.out.paired,map_reads_fasta_pairs.out.sample_name)
-    get_unmapped_reads(map_reads_fasta_pairs.out.sorted_bam,map_reads_fasta_pairs.out.paired,map_reads_fasta_pairs.out.sample_name)
 
+    main:
+    if (params.read_type == "short") {
+        map_reads_fasta_pairs(sample_name, reads, genome, paired)
+        finalize_alignment_bam(
+            map_reads_fasta_pairs.out.sorted_bam,
+            map_reads_fasta_pairs.out.sample_name
+        )
+        if (params.get_mapped_reads) {
+            get_mapped_reads(
+                map_reads_fasta_pairs.out.sorted_bam,
+                map_reads_fasta_pairs.out.paired,
+                map_reads_fasta_pairs.out.sample_name
+            )
+        }
+        if (params.get_unmapped_reads) {
+            get_unmapped_reads(
+                map_reads_fasta_pairs.out.sorted_bam,
+                map_reads_fasta_pairs.out.paired,
+                map_reads_fasta_pairs.out.sample_name
+            )
+        }
+    } else {
+        map_long_reads_fasta_pairs(sample_name, reads, genome)
+        finalize_alignment_bam(
+            map_long_reads_fasta_pairs.out.sorted_bam,
+            map_long_reads_fasta_pairs.out.sample_name
+        )
+        if (params.get_mapped_reads) {
+            get_mapped_reads(
+                map_long_reads_fasta_pairs.out.sorted_bam,
+                map_long_reads_fasta_pairs.out.paired,
+                map_long_reads_fasta_pairs.out.sample_name
+            )
+        }
+        if (params.get_unmapped_reads) {
+            get_unmapped_reads(
+                map_long_reads_fasta_pairs.out.sorted_bam,
+                map_long_reads_fasta_pairs.out.paired,
+                map_long_reads_fasta_pairs.out.sample_name
+            )
+        }
+    }
 }
 
 workflow roadmap_6{
@@ -954,6 +1042,8 @@ include {
     get_unmapped_reads;
     get_mapped_reads;
     map_reads_fasta_pairs;
+    map_long_reads_fasta_pairs;
+    finalize_alignment_bam;
     bowtie2_to_sorted_bam;
     index_star;
     align_star;


### PR DESCRIPTION
- Add --read_type param (short/nanopore/pacbio_clr/pacbio_hifi) to select aligner: bowtie2 for short reads, minimap2 with appropriate preset for long reads (map-ont / map-pb / map-hifi)
- Long reads use a separate CSV format (sample_name, reads) to make the distinction explicit and reduce user error
- Add finalize_alignment_bam process: default output is mapped-only BAM; --keep_unmapped_reads retains all reads in the BAM
- Replace unconditional get_mapped_reads/get_unmapped_reads calls with opt-in flags: --get_mapped_reads and --get_unmapped_reads
- Reuse roadmap9 container (already has minimap2 + samtools) for long reads
- Update roadmaps.md with full long-read documentation, preset table, BAM output flag table, and example commands